### PR TITLE
Fix control flow of for- and while-statements.

### DIFF
--- a/src/cfg/StructuredFlowVisitor.java
+++ b/src/cfg/StructuredFlowVisitor.java
@@ -163,8 +163,11 @@ public class StructuredFlowVisitor extends ASTNodeVisitor
 		CFGNode exprBlock = addEmptyCFGNode(cfg);
 		exprBlock.setASTNode(node.getExpression());
 		
+		CFGNode emptyBlock = addEmptyCFGNode(cfg);
+		
 		cfg.addEdge(initBlock, conditionBlock);
 		cfg.addEdge(conditionBlock, statementCFG.getFirstStatement());
+		cfg.addEdge(conditionBlock, emptyBlock);
 		cfg.addEdge(statementCFG.getLastStatement(), exprBlock);		
 		cfg.addEdge(exprBlock, conditionBlock);
 		
@@ -179,13 +182,15 @@ public class StructuredFlowVisitor extends ASTNodeVisitor
 		
 		loopStack.push(conditionBlock);
 		CFG statementCFG = addStatementBlock(node, cfg);
-		loopStack.push(conditionBlock);
+		//loopStack.push(conditionBlock);
+		loopStack.pop();
 		
 		CFGNode emptyBlock = addEmptyCFGNode(cfg);
 		
 		cfg.addEdge(conditionBlock, statementCFG.getFirstStatement());
-		cfg.addEdge(statementCFG.getLastStatement(), emptyBlock);
-		cfg.addEdge(emptyBlock, conditionBlock);
+		cfg.addEdge(conditionBlock, emptyBlock);
+		cfg.addEdge(statementCFG.getLastStatement(), conditionBlock);
+		
 		
 		returnCFG = cfg;
 		

--- a/testCode/cfgTest.c
+++ b/testCode/cfgTest.c
@@ -1,0 +1,21 @@
+void while_test(void) {
+	int x = 10;
+	while (x) {
+		x--;
+	}
+	printf("%d", x);
+}
+void do_test(void) {
+	int x = 10;
+	do {
+		x--;
+	} while (x);
+	printf("%d", x);
+}
+void for_test(void) {
+	int i;
+	for (i = 0; i < 10; i++) {
+		printf("%d", i);
+	}
+	printf("%d", i);
+}


### PR DESCRIPTION
Conditions in for- and while-statements have now a outgoing edge to
the end of the loop. These edges are the only way to exit the loops.
