### PR TITLE
[dev] gremlin traversal test framework

### DIFF
--- a/gremtest/README.md
+++ b/gremtest/README.md
@@ -1,0 +1,117 @@
+# Testing Gremlin queries
+
+Gremtest is a shell script that lets you test Gremlin queries against an Octopus server.
+
+## Usage
+
+```
+Usage:
+	./gremtest [ -s | -t ] [ -n ] test(suite) ...
+
+	-s | --suite : run specified testsuites. If no testsuites are
+		specified, run all available testsuites. This is the
+		default mode.
+	-t | --test : run specified testcases.
+	-n | --no-import : do not load the test data in the Octopus server.
+		Saves execution time, but may let tests fail because the
+		correct test data is not loaded. Be careful using it.
+```
+
+
+## Directory structure
+
+Gremtest assumes the following directory layout for test suites:
+
+```
+├── test_stdlib
+│   ├── testdata
+│   │   ├── test_cfg.c
+│   │   ├── test_function.c
+│   │   └── test_syntax.c
+│   └── tests
+│       ├── cfg.groovy
+│       ├── function.groovy
+│       └── syntax.groovy
+└── test_suite1
+    ├── testdata
+    │   ├── example1.c
+    │   └── example2.c
+    └── tests
+        ├── suite1_test1.groovy
+        ├── suite1_test2.groovy
+        └── suite1_test3.groovy
+```
+
+Each test suite has its own test data (stored in the directory `testdata`) and
+testcases (groovy scripts in the directory `tests`). This means that every test
+suite will use a database named `testdata.tar.gz`. If you run gremtest, never
+name one of your actual databases `testdata.tar.gz`, as it will be overwritten!
+
+
+## Creating a test script
+
+To create a test script, include gremtest:
+
+```
+!include("gremtest.groovy")
+```
+
+This is a Python escape, which means that you have the full power of Python 3
+available. Multiple lines starting with `!` are seen as one block, so you can
+even include multi-line Python code, such as function definitions.
+
+The `include` command will include a script and process it as if it had been
+part of the current script. This means that an included script can itself
+include other scripts. Scripts are included relative to the current directory.
+
+Then, define your tests, giving it a test name, a closure containing the test code, and an optional flag to enable or disable the test. For example:
+
+``` groovy
+test( "function name traversal", { ->
+	fname = g.V()
+		.has(NODE_TYPE,TYPE_FUNCTION)
+		.has(NODE_CODE,'func1')
+		.values('code')
+		.next()
+	assertEquals( fname, 'func1')
+})
+```
+
+At the end, call `run_tests`:
+
+``` groovy
+run_tests()
+```
+
+## Test output
+
+The script will return a list of test results, all formatted for terminal output. For example:
+
+```
+function name traversal            : PASS
+test with error                    : ERROR
+Division by zero
+at Script7$_run_closure2(doCall:80)
+at Script7(do_test:16)
+at Script7$do_test$0(callCurrent:-1)
+at Script7$do_test$0(callCurrent:-1)
+at Script7(test:40)
+at Script7(test:-1)
+at Script7$test(callCurrent:-1)
+at Script7(run:79)
+at octopus.server.gremlinShell.OctopusGremlinShell(execute:122)
+at octopus.server.gremlinShell.ShellRunnable(evaluteOnShell:145)
+at octopus.server.gremlinShell.ShellRunnable(handleClient:136)
+at octopus.server.gremlinShell.ShellRunnable(processClients:69)
+at octopus.server.gremlinShell.ShellRunnable(run:44)
+
+failing test                       : FAIL
+assert found == expected
+       |        |  |
+       1        |  2
+                false
+1 pass, 1 fail, 1 error(s)
+```
+
+The texts `PASS`, `ERROR` and `FAIL` are color coded to immediately see the results at a glance.
+

--- a/gremtest/gremtest
+++ b/gremtest/gremtest
@@ -31,7 +31,7 @@ run_testcase ()
 	[ -n "$import" ] && \
 		"$rootdir"/import_testcode.sh "$TESTDATADIR"
 
-	octopus-shell co -rxn -d "$dbname" "$1"
+	octopus-shell co -xn -d "$dbname" "$1"
 }
 
 run_suite ()
@@ -46,7 +46,7 @@ run_suite ()
 
 	for t in "$TESTSCRIPTDIR"/*.groovy
 	do
-		octopus-shell co -rxn -d "$dbname" "$t"
+		octopus-shell co -xn -d "$dbname" "$t"
 	done
 }
 

--- a/gremtest/gremtest
+++ b/gremtest/gremtest
@@ -1,0 +1,117 @@
+#!/bin/sh
+#
+# Imports testdata from $TESTDATADIR and runs test scripts from $TESTSCRIPTDIR.
+#
+
+usage ()
+{
+	cat <<EOF;
+Usage:
+	$0 [ -s | -t ] [ -n ] test(suite) ...
+
+	-s | --suite : run specified testsuites. If no testsuites are
+		specified, run all available testsuites. This is the
+		default mode.
+	-t | --test : run specified testcases.
+	-n | --no-import : do not load the test data in the Octopus server.
+		Saves execution time, but may let tests fail because the
+		correct test data is not loaded. Be careful using it.
+
+EOF
+}
+
+rootdir=`dirname "$0"`
+
+run_testcase ()
+{
+	TESTSUITE=`dirname "$1"`/..
+	TESTDATADIR="$TESTSUITE"/testdata
+	dbname=`basename "$TESTDATADIR"`.tar.gz
+
+	[ -n "$import" ] && \
+		"$rootdir"/import_testcode.sh "$TESTDATADIR"
+
+	octopus-shell co -rxn -d "$dbname" "$1"
+}
+
+run_suite ()
+{
+	TESTSUITE="$1"
+	TESTDATADIR="$rootdir"/"$TESTSUITE"/testdata
+	TESTSCRIPTDIR="$rootdir"/"$TESTSUITE"/tests
+	dbname=`basename "$TESTDATADIR"`.tar.gz
+
+	[ -n "$import" ] && \
+		"$rootdir"/import_testcode.sh "$TESTDATADIR"
+
+	for t in "$TESTSCRIPTDIR"/*.groovy
+	do
+		octopus-shell co -rxn -d "$dbname" "$t"
+	done
+}
+
+mode=suites
+import=1
+
+while [ "$1" != "" ]
+do
+	case $1 in
+		-h | --help)
+			usage
+			exit
+			;;
+		-s | --suite)
+			mode=suites
+			;;
+		-t | --test)
+			mode=tests
+			;;
+		-n | --no-import)
+			import=""
+			;;
+		-*)
+			echo "Unknown option \"$1\""
+			usage
+			exit 1
+			;;
+		*)
+			# start of positional arguments, stop parsing
+			break
+			;;
+	esac
+	shift
+done
+
+TESTS="$@"
+
+if [ -z "$TESTS" -a $mode = "suites" ]
+then
+	TESTS="$rootdir/test_*"
+fi
+
+if [ -z "$TESTS" ]
+then
+	echo "Error: no tests specified"
+	exit 1
+fi
+
+case $mode in
+	suites)
+		echo $TESTS
+		for test in $TESTS
+		do
+			echo "==> Running $test..."
+			run_suite "$test"
+		done
+		break
+		;;
+	tests)
+		for test in $TESTS
+		do
+			echo "==> Running $test..."
+			run_testcase "$test"
+		done
+		break
+		;;
+esac
+

--- a/gremtest/gremtest.groovy
+++ b/gremtest/gremtest.groovy
@@ -1,0 +1,68 @@
+import groovy.transform.Field;
+import org.codehaus.groovy.runtime.StackTraceUtils;
+
+@Field def gremtest_results = []
+@Field def gremtest_result_count = [ 'pass':0, 'fail':0, 'error':0 ]
+
+//
+// The test runner function. Used internally.
+//
+def do_test( name, testclosure ) {
+	red = '\u001b[31;1m'
+	green = '\u001b[32;1m'
+	yellow = '\u001b[33;1m'
+	reset = '\u001b[0m'
+	try {
+		testclosure()
+		gremtest_result_count['pass']++
+		sprintf "%-35s: ${green}PASS${reset}", name
+	} catch (AssertionError e) {
+		gremtest_result_count['fail']++
+		sprintf "%-35s: ${red}FAIL${reset}\n%s", [name,e.getMessage()]
+	} catch (Exception e) {
+		gremtest_result_count['error']++
+		sw = new StringWriter()
+		pw = new PrintWriter(sw)
+		StackTraceUtils.printSanitizedStackTrace(e,pw)
+		sprintf "%-35s: ${yellow}ERROR${reset}\n%s\n%s", [name, e.getMessage(), sw.toString() ]
+	}
+}
+
+//
+// test(name, testclosure, enable=true)
+//
+// Executes a test (if enable is true) and collects the results. Tests are
+// defined as a closure. The optional parameter enable can be used to disable
+// a test.
+//
+def test( name, testclosure, enable=true ) {
+	if (enable) {
+		r = do_test(name,testclosure)
+		gremtest_results << r
+	}
+}
+
+//
+// summarize the collected results and return it to the caller. Use this as
+// the last command in your test script.
+//
+def run_tests () {
+	gremtest_results << sprintf ("%d pass, %d fail, %d error(s)", gremtest_result_count['pass'], gremtest_result_count['fail'], gremtest_result_count['error'])
+	gremtest_results
+}
+
+//
+// Assertions
+//
+
+// check a condition which is defined as a closure.
+def assertCond(condition,found,expected) {
+	assert condition(found,expected)
+}
+
+def assertEquals(found,expected) {
+	assert found == expected
+}
+
+
+

--- a/gremtest/import_testcode.sh
+++ b/gremtest/import_testcode.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Usage:
+#
+#    import_testcode.sh /path/to/testcodedir
+#
+
+codedir_parent=`dirname "$1"`
+project_name=`basename "$1"`
+
+tar -zcvf "$project_name".tar.gz -C "$codedir_parent" "$project_name" && \
+octopus-project delete "$project_name".tar.gz && \
+joern-import "$project_name".tar.gz && \
+rm "$project_name".tar.gz
+

--- a/gremtest/test_stdlib/testdata/test_cfg.c
+++ b/gremtest/test_stdlib/testdata/test_cfg.c
@@ -1,0 +1,19 @@
+void popa_ex_2_5 ()
+{
+        x = a+b;
+        y = a+b;
+        while (y>a+b) {
+                a = a + 1;
+                x = a + b;
+        }
+}
+
+void popa_ex_2_6 ()
+{
+	x = 5;
+	y = 1;
+	while (x>1) {
+		y = x*y;
+		x = x-1;
+	}
+}

--- a/gremtest/test_stdlib/testdata/test_function.c
+++ b/gremtest/test_stdlib/testdata/test_function.c
@@ -1,0 +1,5 @@
+
+void function_location_1() {
+	printf("Hello");
+}
+

--- a/gremtest/test_stdlib/testdata/test_syntax.c
+++ b/gremtest/test_stdlib/testdata/test_syntax.c
@@ -1,0 +1,22 @@
+void test_astnodes ()
+{
+	x = 8 * ++a - b;
+}
+
+void test_funccall (char *name)
+{
+	fprintf(STDERR, "Hello %s!\n", name);
+}
+
+void test_funccall_from_assignment ()
+{
+	x = 45 + 2*sqrt(9);
+}
+
+void test_funccall_from_nested_assignment ()
+{
+	x = 45 + (a = 5 + sqrt(9));
+}
+
+int declared_function(char *, int);
+

--- a/gremtest/test_stdlib/tests/cfg.groovy
+++ b/gremtest/test_stdlib/tests/cfg.groovy
@@ -1,0 +1,45 @@
+!include("gremtest.groovy")
+
+test("toExitNode", {
+	astnode =
+		g.V().has('type','Function').has('code','popa_ex_2_5')
+		.functionToAST()
+		.astNodes()
+		.has('type','AssignmentExpression')
+		.has('code','a = a + 1')
+		.next()
+	functionId = astnode.value('functionId')
+	exitnode_expected =
+		g.V().has('functionId',functionId)
+		.has('type','CFGExitNode')
+		.next()
+	exitnode_found =
+		__.inject(astnode)
+		.toExitNode()
+		.next()
+	assertEquals(exitnode_found,exitnode_expected)
+})
+
+test("toExitNodeMultipleFunctionsPreserveOrder", {
+	astnodes =
+		g.V().has('type','Function').has('code',textRegex('popa_ex_2_.'))
+		.functionToAST()
+		.astNodes()
+		.has('type','AssignmentExpression')
+		.or( has('code','a = a + 1'), has('code','x = x - 1'))
+		.collect()
+	functionIds = astnodes.collect{ it.value('functionId') }
+	exitnodes_expected =
+		functionIds.collect{ fid ->
+			g.V().has('type','CFGExitNode')
+			.has('functionId',fid).next()
+		}
+	exitnodes_found =
+		__.inject(*astnodes)
+		.toExitNode()
+		.collect()
+	assertEquals(exitnodes_found,exitnodes_expected)
+})
+
+
+run_tests()

--- a/gremtest/test_stdlib/tests/function.groovy
+++ b/gremtest/test_stdlib/tests/function.groovy
@@ -1,0 +1,17 @@
+!include("gremtest.groovy")
+
+test("functionToLocationStr", {
+	func =
+		g.V().has('type','Function').has('code','function_location_1')
+		.next()
+	loc_found =
+		__.inject(func)
+		.functionToLocationStr()
+		.next()
+	prefix = loc_found.find("^.*testdata.tar.gz/src/")
+	loc_expected = prefix + "testdata/test_function.c:" + func.value('location')
+
+	assertEquals(loc_found,loc_expected)
+})
+
+run_tests()

--- a/gremtest/test_stdlib/tests/syntax.groovy
+++ b/gremtest/test_stdlib/tests/syntax.groovy
@@ -1,0 +1,416 @@
+!include("gremtest.groovy")
+
+test("astNodes_on_leaf", {
+	identifiers =
+	g.V().has('type','Function').has('code','test_astnodes')
+	.functionToAST()
+	.astNodes()
+	.has('type','Identifier')
+	.collect()
+	subnodes = __.inject(identifiers[0])
+		.astNodes()
+		.collect()
+
+	assertEquals(subnodes,[identifiers[0]])
+})
+
+test("astNodes_on_root", {
+	traversed_nodes =
+		g.V().has('type','Function').has('code','test_astnodes')
+		.functionToAST()
+		.astNodes()
+		.collect() as Set
+
+	functionId = traversed_nodes[0].value('functionId')
+
+	all_function_ast_nodes =
+		g.V().has('functionId',functionId)
+		.has('type',P.not(P.within('CFGEntryNode','CFGExitNode','Symbol')))
+		.collect() as Set
+
+	assertEquals(traversed_nodes,all_function_ast_nodes)
+})
+
+test("ithChildren", {
+	children_found =
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','ArgumentList')
+		.ithChildren('1')
+		.map{ [ it.get().value(NODE_CHILDNUM), it.get().value('type'), it.get().value('code') ] }
+		.collect()
+	children_expected = [ ['1','Argument','"Hello %s!\\n"' ] ]
+	assertEquals(children_found,children_expected)
+})
+
+test("siblings_single_node", {
+	parent = 
+		g.V().has('type','Function').has('code','test_astnodes')
+		.functionToAST()
+		.astNodes()
+		.has('type','AssignmentExpression')
+		.next()
+	children = __.inject(parent).out(AST_EDGE).collect()
+
+	siblings_expected = (children - children[0]) as Set
+	siblings_found =
+		__.inject(children[0])
+		.siblings()
+		.collect() as Set
+
+	assertEquals(siblings_found, siblings_expected)
+})
+
+test("siblings_of_siblings", {
+	parent = 
+		g.V().has('type','Function').has('code','test_astnodes')
+		.functionToAST()
+		.astNodes()
+		.has('type','AssignmentExpression')
+		.next()
+	children = __.inject(parent).out(AST_EDGE).collect()
+	siblings_expected =
+		(children - children[0]) + (children - children[1]) as Set
+	siblings_found =
+		__.inject(children[0],children[1])
+		.siblings()
+		.collect() as Set
+	assertEquals(siblings_found, siblings_expected)
+})
+
+test("statements_from_leaf_ast_node", {
+	leafnode =
+		g.V().has('type','Function').has('code','test_astnodes')
+		.functionToAST()
+		.astNodes()
+		.has('type','Identifier')
+		.collect()[-1]
+	functionId = leafnode.value('functionId')
+	cfgnode_expected = 
+		g.V()
+		.has('functionId',functionId)
+		.has('isCFGNode','True')
+		.has('type',P.not(P.within('CFGEntryNode','CFGExitNode')))
+		.next()
+	cfgnode_found =
+		__.inject(leafnode)
+		.statements()
+		.next()
+
+	assertEquals(cfgnode_found, cfgnode_expected)
+})
+
+test("statements_from_cfg_node", {
+	cfgnode =
+		g.V().has('type','Function').has('code','test_astnodes')
+		.functionToAST()
+		.astNodes()
+		.has('type','ExpressionStatement')
+		.collect()[-1]
+	cfgnode_found =
+		__.inject(cfgnode)
+		.statements()
+		.next()
+
+	assertEquals(cfgnode_found, cfgnode)
+})
+
+test("lval", {
+	lvalnode =
+		g.V().has('type','Function').has('code','test_astnodes')
+		.functionToAST()
+		.astNodes()
+		.has('type','AssignmentExpression')
+		.lval()
+		.values('code')
+		.next()
+	assertEquals(lvalnode, "x")
+})
+
+test("rval", {
+	rvalnode =
+		g.V().has('type','Function').has('code','test_astnodes')
+		.functionToAST()
+		.astNodes()
+		.has('type','AssignmentExpression')
+		.rval()
+		.values('code')
+		.next()
+	assertEquals(rvalnode, "8 * ++ a - b")
+})
+
+test("callToArguments", {
+	args_found =
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','CallExpression')
+		.callToArguments()
+		.map{ [ it.get().value('childNum'), it.get().value('type'), it.get().value('code') ]}
+		.collect() as Set
+	args_expected = [ ['0', 'Argument', 'STDERR'],
+		['1', 'Argument', '"Hello %s!\\n"'],
+		['2', 'Argument', 'name']] as Set
+	assertEquals(args_found, args_expected)
+})
+
+test("ithArguments", {
+	args_found =
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','CallExpression')
+		.ithArguments('1')
+		.map{ [ it.get().value('childNum'), it.get().value('type'), it.get().value('code') ]}
+		.collect() as Set
+	args_expected = [ ['1', 'Argument', '"Hello %s!\\n"'] ] as Set
+	assertEquals(args_found, args_expected)
+})
+
+test("argToCall", {
+	callnode_expected =
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','CallExpression')
+		.next()
+	callnode_found = __.inject(callnode_expected)
+		.ithArguments('1')
+		.argToCall()
+		.next()
+	assertEquals(callnode_found, callnode_expected)
+})
+
+test("callToCallee", {
+	callee =
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','CallExpression')
+		.callToCallee()
+		.map{ [ it.get().value('childNum'), it.get().value('type'), it.get().value('code') ]}
+		.collect()
+	assertEquals(callee, [['0','Callee','fprintf']])
+})
+
+test("calleeToCall", {
+	callnode_expected =
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','CallExpression')
+		.next()
+	functionId = callnode_expected.value('functionId')
+	callnode_found = 
+		g.V().has('type','Callee').has('functionId',functionId)
+		.calleeToCall()
+		.next()
+	assertEquals(callnode_found, callnode_expected)
+})
+
+test("callToAssigns", {
+
+	assignmentnodes_expected = 
+		g.V().has('type','Function').has('code','test_funccall_from_assignment')
+		.functionToAST()
+		.astNodes()
+		.has('type','AssignmentExpression')
+		.collect() as Set
+
+	assignmentnodes_found =
+		g.V().has('type','Function').has('code','test_funccall_from_assignment')
+		.functionToAST()
+		.astNodes()
+		.has('type','CallExpression')
+		.callToAssigns()
+		.collect() as Set
+
+	assertEquals(assignmentnodes_found, assignmentnodes_expected)
+})
+
+test("callToAssignsNested", {
+
+	assignmentnodes_expected = 
+		g.V().has('type','Function').has('code','test_funccall_from_nested_assignment')
+		.functionToAST()
+		.astNodes()
+		.has('type','AssignmentExpression')
+		.collect() as Set
+
+	assignmentnodes_found =
+		g.V().has('type','Function').has('code','test_funccall_from_nested_assignment')
+		.functionToAST()
+		.astNodes()
+		.has('type','CallExpression')
+		.callToAssigns()
+		.collect() as Set
+
+	assertEquals(assignmentnodes_found, assignmentnodes_expected)
+})
+
+test("matchParents", {
+
+	nodes_expected = 
+		g.V().has('type','Function').has('code','test_funccall_from_nested_assignment')
+		.functionToAST()
+		.astNodes()
+		.has('type','AdditiveExpression')
+		.collect() as Set
+
+	nodes_found =
+		g.V().has('type','Function').has('code','test_funccall_from_nested_assignment')
+		.functionToAST()
+		.astNodes()
+		.has('type','CallExpression')
+		.matchParents( has('type','AdditiveExpression') )
+		.collect() as Set
+
+	assertEquals(nodes_found, nodes_expected)
+})
+
+
+test("matchParentsEnclosingStatement", {
+
+	nodes_expected = 
+		g.V().has('type','Function').has('code','test_funccall_from_nested_assignment')
+		.functionToAST()
+		.astNodes()
+		.has('type','ExpressionStatement')
+		.collect() as Set
+
+	nodes_found =
+		g.V().has('type','Function').has('code','test_funccall_from_nested_assignment')
+		.functionToAST()
+		.astNodes()
+		.has('type','CallExpression')
+		.matchParents( has('type','ExpressionStatement') )
+		.collect() as Set
+
+	assertEquals(nodes_found, nodes_expected)
+})
+
+test("matchParentsEnclosingStatementOnSelf", {
+
+	node_expected = 
+		g.V().has('type','Function').has('code','test_funccall_from_nested_assignment')
+		.functionToAST()
+		.astNodes()
+		.has('type','ExpressionStatement')
+		.next()
+
+	nodes_found =
+		__.inject(node_expected)
+		.matchParents( has('type','ExpressionStatement') )
+		.collect() as Set
+
+	assertEquals(nodes_found, [node_expected] as Set)
+})
+
+test("arg", {
+	arg_expected =
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','ArgumentList')
+		.ithChildren('2')
+		.next()
+	arg_found = 
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.arg('fprintf','2')
+		.next()
+	assertEquals(arg_found, arg_expected)
+})
+
+test("param", {
+	param_expected =
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','Parameter')
+		.has('code','char * name')
+		.next()
+	param_found = 
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.param('.* name')
+		.next()
+	assertEquals(param_found, param_expected)
+})
+
+test("paramsToNames", {
+	paramnames_expected =
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','ParameterType')
+		.siblings()
+		.next()
+	paramnames_found = 
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','Parameter')
+		.paramsToNames()
+		.next()
+	assertEquals(paramnames_found, paramnames_expected)
+})
+
+test("paramsToTypes", {
+	paramtypes_expected =
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','ParameterType')
+		.next()
+	paramtypes_found = 
+		g.V().has('type','Function').has('code','test_funccall')
+		.functionToAST()
+		.astNodes()
+		.has('type','Parameter')
+		.paramsToTypes()
+		.next()
+	assertEquals(paramtypes_found, paramtypes_expected)
+})
+
+test("paramsToTypesDeclarationOnly", {
+	paramtypes_expected =
+		g.V().has('type','Function').has('code','declared_function')
+		.functionToAST()
+		.astNodes()
+		.has('type','ParameterType')
+		.collect()
+	paramtypes_found = 
+		g.V().has('type','Function').has('code','declared_function')
+		.functionToAST()
+		.astNodes()
+		.has('type','Parameter')
+		.paramsToTypes()
+		.collect()
+	assertEquals(paramtypes_found, paramtypes_expected)
+})
+
+test("paramsToNamesDeclarationOnly", {
+	paramnames_expected =
+		g.V().has('type','Function').has('code','declared_function')
+		.functionToAST()
+		.astNodes()
+		.has('type','Parameter')
+		.children()
+		.not(has('type','ParameterType'))
+		.collect()
+	paramnames_found = 
+		g.V().has('type','Function').has('code','declared_function')
+		.functionToAST()
+		.astNodes()
+		.has('type','Parameter')
+		.paramsToNames()
+		.collect()
+	assertEquals(paramnames_found, paramnames_expected)
+})
+
+
+
+run_tests()
+

--- a/projects/octopus/python/octopus-tools/scripts/octopus-shell
+++ b/projects/octopus/python/octopus-tools/scripts/octopus-shell
@@ -98,12 +98,6 @@ connect_parser.add_argument(
     help="destroy the shell at the end of the session.")
 
 connect_parser.add_argument(
-    "-r", "--runscript",
-    action='store_true',
-    default=False,
-    help="interpret special script commands in input.")
-
-connect_parser.add_argument(
     "script",
     type=argparse.FileType('r'),
     nargs="?",

--- a/projects/octopus/python/octopus-tools/scripts/octopus-shell
+++ b/projects/octopus/python/octopus-tools/scripts/octopus-shell
@@ -9,7 +9,7 @@ from octopus.shell.octopus_console import OctopusInteractiveConsole
 from octopus.shell.octopus_shell import OctopusShellConnection
 
 
-def connect(host, port, script=None):
+def connect(host, port, script=None, quit=False):
     try:
         octopus_shell = OctopusShellConnection(host, port)
         octopus_shell.connect()
@@ -21,6 +21,8 @@ def connect(host, port, script=None):
             else:
                 console = OctopusInteractiveConsole(octopus_shell)
                 console.interact()
+            if quit:
+                console.runsource("quit")
         except SystemExit:
             pass
 
@@ -62,6 +64,7 @@ connect_parser = subparsers.add_parser(
                  "If shellport is specified, octopus-shell directly connects to the shell associated with that port. "
                  "If a database name is specified, octopus-shell connects to the shell associated with that database "
                  "if it is unique. If no shell is available one will be created first. "
+                 "If told to always create a new shell, a new shell will be created. "
                  "Otherwise all available shells for that database are shown. "
                  "If neither a port nor database name is specified and only a single shell is available, octopus-shell "
                  "directly connects to that shell. "
@@ -76,11 +79,29 @@ group.add_argument(
     default=None,
     help="connect to a shell associated with this database")
 
-group.add_argument(
+connect_parser.add_argument(
+    "-n", "--newshell",
+    action='store_true',
+    default=False,
+    help="always create a new shell (requires -d|--dbname)")
+
+connect_parser.add_argument(
     "-q", "--shellport",
     type=int,
     default=None,
     help="connect to the shell associated with this port")
+
+connect_parser.add_argument(
+    "-x", "--exitshell",
+    action='store_true',
+    default=False,
+    help="destroy the shell at the end of the session.")
+
+connect_parser.add_argument(
+    "-r", "--runscript",
+    action='store_true',
+    default=False,
+    help="interpret special script commands in input.")
 
 connect_parser.add_argument(
     "script",
@@ -129,14 +150,14 @@ if args.subcommand in ['connect', 'co']:
 
     if len(shells) == 0 and not args.dbname:
         print("No matching shells found.", file=sys.stderr)
-    elif len(shells) == 0 and args.dbname:
+    elif args.dbname and  ( len(shells) == 0 or args.newshell ):
         shellport = shell_manager.create(args.dbname)
         print("Connecting to database '{}' on port {}.".format(args.dbname, shellport), file=sys.stderr)
-        connect(args.server, shellport, args.script)
+        connect(args.server, shellport, args.script, args.exitshell)
     elif len(shells) == 1:
         shellport, dbname, name, occupied = shells[0]
         print("Connecting to database '{}' on port {}.".format(dbname, shellport), file=sys.stderr)
-        connect(args.server, shellport, args.script)
+        connect(args.server, shellport, args.script, args.exitshell)
     else:
         print("Found {} shells.".format(len(shells)), file=sys.stderr)
         printshells(shells, sys.stderr)


### PR DESCRIPTION
Changes to octopus-shell:
- option `-n` to always create a new shell
- option `-x` to destroy shell automatically
- interpret multiline blocks of Python escapes in scripts

Added test framework:
- gremtest groovy script
- testsuite for stdlib traversals
- shell script to import test data into octopus
- shell script to run the tests