### PR TITLE
Fix switch statement control flow analysis

### DIFF
--- a/src/cfg/C/CCFGFactory.java
+++ b/src/cfg/C/CCFGFactory.java
@@ -360,7 +360,8 @@ public class CCFGFactory extends CFGFactory
 					.entrySet())
 			{
 				// Skip labels that aren't for switch statements.
-				if (!block.getKey().matches("^(case|default).*")) {
+				if (!block.getKey().matches("^(case|default).*"))
+				{
 					nonCaseLabels.put(block.getKey(), block.getValue());
 					continue;
 				}

--- a/src/cfg/C/CCFGFactory.java
+++ b/src/cfg/C/CCFGFactory.java
@@ -1,5 +1,6 @@
 package cfg.C;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -354,9 +355,16 @@ public class CCFGFactory extends CFGFactory
 
 			boolean defaultLabel = false;
 
+			HashMap<String, CFGNode> nonCaseLabels = new HashMap<>();
 			for (Entry<String, CFGNode> block : switchBody.getLabels()
 					.entrySet())
 			{
+				// Skip labels that aren't for switch statements.
+				if (!block.getKey().matches("^(case|default).*")) {
+					nonCaseLabels.put(block.getKey(), block.getValue());
+					continue;
+				}
+
 				if (block.getKey().equals("default"))
 				{
 					defaultLabel = true;
@@ -364,6 +372,13 @@ public class CCFGFactory extends CFGFactory
 				switchBlock.addEdge(conditionContainer, block.getValue(),
 						block.getKey());
 			}
+
+			// Hide case/default labels from upstream CFG analysis, they can't
+			// reference internal labels anyway and this prevents bugs with
+			// nested switch statements where the parent switch statement
+			// references the childs labels.
+			switchBlock.setLabels(nonCaseLabels);
+
 			for (CFGEdge edge : switchBody.ingoingEdges(switchBody
 					.getExitNode()))
 			{


### PR DESCRIPTION
The switch statement control flow analysis has two bugs. Currently it
adds CF edges to every label in the switch body, including: 1)
labels not related to the control flow [e.g. goto labels, not
case/default labels], and 2) for nested switch statements the parent
switch statement includes direct edges to the child switch statements
labels. This change skips goto labels, and doesn't propogate
case/default labels up to avoid the nested switch statement problem
(other contexts can't reference the switch statement case/default
labels anyway so that should be fine.)

Builds clean and unit tests pass.

I also have a change queued up for jpanlib but I can't tell, is jpanlib actually
used? The gradle files required work to even build, and I can't find any
references to it from the octopus-platform/joern or
octopus-platform/octopus repos.
