### PR TITLE
Export all node properties and don't store empty keys

### DIFF
--- a/projects/extensions/jpanlib/src/main/java/outputModules/csv/CSVWriterImpl.java
+++ b/projects/extensions/jpanlib/src/main/java/outputModules/csv/CSVWriterImpl.java
@@ -18,7 +18,9 @@ public abstract class CSVWriterImpl implements WriterImpl {
 
 	final String[] nodeProperties = { NodeKeys.NODE_TYPE, NodeKeys.CODE,
 			NodeKeys.LOCATION, NodeKeys.FUNCTION_ID,
-			NodeKeys.CHILD_NUMBER, NodeKeys.IS_CFG_NODE };
+			NodeKeys.CHILD_NUMBER, NodeKeys.IS_CFG_NODE , NodeKeys.OPERATOR,
+			NodeKeys.BASE_TYPE, NodeKeys.COMPLETE_TYPE, NodeKeys.IDENTIFIER
+	};
 
 	final String[] edgeProperties = { EdgeKeys.VAR };
 

--- a/projects/octopus/src/main/java/octopus/server/importer/csv/titan/CSVImporter.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/csv/titan/CSVImporter.java
@@ -225,7 +225,8 @@ public class CSVImporter
 
 		for (int i = 3; i < row.length; i++)
 		{
-			edge.property(edgeFile.getKeys()[i], row[i]);
+			if (!row[i].equals(""))
+				edge.property(edgeFile.getKeys()[i], row[i]);
 		}
 
 	}

--- a/projects/octopus/src/main/java/octopus/server/importer/csv/titan/CSVImporter.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/csv/titan/CSVImporter.java
@@ -176,8 +176,9 @@ public class CSVImporter
 
 	private void setPropertiesOnVertex(Vertex vertex, String[] row, String[] keys)
 	{
-		for(int i = 2; i < row.length; i++){
-			vertex.property(keys[i-1], row[i]);
+		for(int i = 2; i < row.length; i++) {
+			if (!row[i].equals(""))
+					vertex.property(keys[i - 1], row[i]);
 		}
 	}
 


### PR DESCRIPTION
Currently jpanlib doesn't output a number of valid NodeKeys in the CSV
writer, meaning they don't get imported into octopus. This PR fixes
that, and also changes the titan CSV importer to not write empty vertex
properties. These two changes combined, despite adding more data to the
DB, reduce total DB size by 10%, tested on libav 11.6, ~4.7GB -> ~4.2GB.

Also, I haven't received a reply to https://github.com/octopus-platform/joern/pull/131 so I'm still not sure how to submit changes like this. jpanlib is split across two repos and I'm not sure how changes to it should be submitted.
