### PR TITLE
Simplify dynamically generated UDG expressions

### DIFF
--- a/projects/extensions/joern-fuzzyc/src/main/java/udg/useDefAnalysis/CUseDefExpression.java
+++ b/projects/extensions/joern-fuzzyc/src/main/java/udg/useDefAnalysis/CUseDefExpression.java
@@ -1,0 +1,12 @@
+package udg.useDefAnalysis;
+
+public class CUseDefExpression {
+    /**
+     * Eliminate redundant "& * " and "* & " patterns that can occur in
+     * dynamically generated UseDef references.
+     */
+    public static String simplify(String expr)
+    {
+        return expr.replace("& * ", "").replace("* & ", "");
+    }
+}

--- a/projects/extensions/joern-fuzzyc/src/main/java/udg/useDefAnalysis/environments/ArgumentEnvironment.java
+++ b/projects/extensions/joern-fuzzyc/src/main/java/udg/useDefAnalysis/environments/ArgumentEnvironment.java
@@ -3,6 +3,7 @@ package udg.useDefAnalysis.environments;
 import java.util.LinkedList;
 
 import udg.ASTProvider;
+import udg.useDefAnalysis.CUseDefExpression;
 import udg.useDefAnalysis.environments.EmitDefAndUseEnvironment;
 
 public class ArgumentEnvironment extends EmitDefAndUseEnvironment
@@ -15,20 +16,15 @@ public class ArgumentEnvironment extends EmitDefAndUseEnvironment
 	{
 		if (isDef(child))
 		{
-			// For tainted arguments, add "* symbol" instead of symbol
-			// to defined symbols. Make an exception if symbol starts with '& '
-
 			LinkedList<String> derefChildSymbols = new LinkedList<String>();
 			for (String symbol : childSymbols)
 			{
-
+				derefChildSymbols.add(CUseDefExpression.simplify("* " + symbol));
 				if (!symbol.startsWith("& "))
 				{
-					derefChildSymbols.add("* " + symbol);
 					// !patch to see if we can detect macro-sources!
 					derefChildSymbols.add(symbol);
-				} else
-					derefChildSymbols.add(symbol.substring(2));
+				}
 			}
 
 			defSymbols.addAll(derefChildSymbols);

--- a/projects/extensions/joern-fuzzyc/src/main/java/udg/useDefAnalysis/environments/ArrayIndexingEnvironment.java
+++ b/projects/extensions/joern-fuzzyc/src/main/java/udg/useDefAnalysis/environments/ArrayIndexingEnvironment.java
@@ -3,6 +3,7 @@ package udg.useDefAnalysis.environments;
 import java.util.LinkedList;
 
 import udg.ASTProvider;
+import udg.useDefAnalysis.CUseDefExpression;
 import udg.useDefAnalysis.environments.EmitUseEnvironment;
 
 public class ArrayIndexingEnvironment extends EmitUseEnvironment
@@ -15,7 +16,7 @@ public class ArrayIndexingEnvironment extends EmitUseEnvironment
 		LinkedList<String> derefedChildren = new LinkedList<String>();
 		for (String c : childSymbols)
 		{
-			derefedChildren.add("* " + c);
+			derefedChildren.add(CUseDefExpression.simplify("* " + c));
 		}
 
 		symbols.addAll(derefedChildren);

--- a/projects/extensions/joern-fuzzyc/src/main/java/udg/useDefAnalysis/environments/PtrMemberAccessEnvironment.java
+++ b/projects/extensions/joern-fuzzyc/src/main/java/udg/useDefAnalysis/environments/PtrMemberAccessEnvironment.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 import udg.ASTProvider;
+import udg.useDefAnalysis.CUseDefExpression;
 import udg.useDefAnalysis.environments.UseDefEnvironment;
 import udg.useDefGraph.UseOrDef;
 
@@ -20,7 +21,7 @@ public class PtrMemberAccessEnvironment extends UseDefEnvironment
 		LinkedList<String> derefedChildren = new LinkedList<String>();
 		for (String c : symbols)
 		{
-			derefedChildren.add("* " + c);
+			derefedChildren.add(CUseDefExpression.simplify("* " + c));
 		}
 
 		retval.addAll(derefedChildren);

--- a/projects/extensions/joern-fuzzyc/src/main/java/udg/useDefAnalysis/environments/UnaryOpEnvironment.java
+++ b/projects/extensions/joern-fuzzyc/src/main/java/udg/useDefAnalysis/environments/UnaryOpEnvironment.java
@@ -3,6 +3,7 @@ package udg.useDefAnalysis.environments;
 import java.util.LinkedList;
 
 import udg.ASTProvider;
+import udg.useDefAnalysis.CUseDefExpression;
 import udg.useDefAnalysis.environments.EmitUseEnvironment;
 
 public class UnaryOpEnvironment extends EmitUseEnvironment
@@ -18,8 +19,9 @@ public class UnaryOpEnvironment extends EmitUseEnvironment
 		{
 			for (String symbol : childSymbols)
 			{
-				symbols.add("& " + symbol);
+				symbols.add(CUseDefExpression.simplify("& " + symbol));
 			}
+
 			return;
 		}
 
@@ -36,7 +38,7 @@ public class UnaryOpEnvironment extends EmitUseEnvironment
 		LinkedList<String> derefedChildren = new LinkedList<String>();
 		for (String c : childSymbols)
 		{
-			derefedChildren.add("* " + c);
+			derefedChildren.add(CUseDefExpression.simplify("* " + c));
 		}
 
 		retval.addAll(derefedChildren);

--- a/projects/extensions/joern-fuzzyc/src/test/java/tests/udg/testUseDefGraphCreator.java
+++ b/projects/extensions/joern-fuzzyc/src/test/java/tests/udg/testUseDefGraphCreator.java
@@ -1,5 +1,6 @@
 package tests.udg;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -36,6 +37,7 @@ public class testUseDefGraphCreator extends TestDBTestsBatchInserter
 		aMap.put("plusEqualsUse", "int f(){ x += y; }");
 		aMap.put("ddg_test_struct",
 				"int ddg_test_struct(){ struct my_struct foo; foo.bar = 10; copy_somehwere(foo); }");
+		aMap.put("udg_simplify_expressions", "int test() { func(&a[0]); }");
 
 		functionMap = aMap;
 	}
@@ -87,6 +89,16 @@ public class testUseDefGraphCreator extends TestDBTestsBatchInserter
 		assertOnlyUseForXFound(useDefGraph, "z");
 	}
 
+	// Test that expressions are simplified, e.g. lack of an "& * a" element
+	@Test
+	public void test_simplified_expression()
+	{
+		UseDefGraph useDefGraph = createUDGForFunction("udg_simplify_expressions");
+		assertEquals(useDefGraph.keySet().size(), 1);
+		assertTrue(useDefGraph.keySet().contains("a"));
+	}
+
+
 	private UseDefGraph createUDGForFunction(String functionName)
 	{
 		String code = functionMap.get(functionName);
@@ -107,7 +119,7 @@ public class testUseDefGraphCreator extends TestDBTestsBatchInserter
 		assertTrue(usesAndDefs != null);
 		assertTrue(usesAndDefs.size() > 0);
 
-		// make sure only 'uses' of x exist
+		// make sure only 'definitions' of x exist
 		for (UseOrDefRecord r : usesAndDefs)
 		{
 			assertTrue(r.isDef());
@@ -139,7 +151,7 @@ public class testUseDefGraphCreator extends TestDBTestsBatchInserter
 
 		boolean isDefined = false, isUsed = false;
 
-		// make sure only 'definitions' of x exist
+		// make sure 'definitions' and 'uses' of x exist
 		for (UseOrDefRecord r : usesAndDefs)
 		{
 			if (r.isDef())


### PR DESCRIPTION
For example, turn '& * a' into just 'a' in the use-def graph. The mangled symbols come up frequently now, e.g. for expressions like &a->b or &c[5].