### PR TITLE
Graphstreamimporter

### DIFF
--- a/projects/octopus/build.gradle
+++ b/projects/octopus/build.gradle
@@ -34,6 +34,7 @@ dependencies{
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.13'
   compile group: 'org.apache.tinkerpop', name: 'gremlin-driver', version: '3.0.1-incubating'
   compile group: 'com.opencsv', name: 'opencsv', version: '3.5'
+  compile group: 'org.graphstream', name: 'gs-core', version: '1.3'
 
   runtime group: 'ch.qos.logback', name: 'logback-core', version: '1.1.3'
   runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.3'

--- a/projects/octopus/python/octopus-tools/octopus/importer/OctopusImporter.py
+++ b/projects/octopus/python/octopus-tools/octopus/importer/OctopusImporter.py
@@ -37,5 +37,6 @@ class OctopusImporter:
 
     def executeImporterPlugin(self):
         print('Executing importer plugin')
+        print('plugin name: %s\n' % self.pluginName)
         pluginSettings = { 'projectName' : self.projectName }
         print(self.pluginExecutor.execute(self.pluginName, self.pluginClass, pluginSettings))

--- a/projects/octopus/python/octopus-tools/scripts/octopus-dgsimport
+++ b/projects/octopus/python/octopus-tools/scripts/octopus-dgsimport
@@ -1,0 +1,31 @@
+#!python
+
+import argparse
+
+from octopus.server.plugin_executor import PluginExecutor
+
+parser = argparse.ArgumentParser(description="Generic Graphstream Importer")
+
+parser.add_argument(
+    "-s", "--server-host",
+    type=str,
+    default="localhost",
+    help="set the hostname of the octopus server")
+
+parser.add_argument(
+    "-p", "--server-port",
+    type=int,
+    default=2480,
+    help="set the port number of the octopus server")
+
+parser.add_argument(
+    "project",
+    type=str,
+    help="The project to import into.")
+
+args = parser.parse_args()
+
+executor = PluginExecutor(args.server_host, args.server_port)
+
+settings = { 'projectName' : args.project}
+executor.execute("", "octopus.plugins.graphstreamimporter.GraphstreamImporterPlugin", settings)

--- a/projects/octopus/python/octopus-tools/setup.py
+++ b/projects/octopus/python/octopus-tools/setup.py
@@ -20,5 +20,5 @@ setup(
         'octopus.shell': ['data/banner.txt'],
         'octopus.shell.config': ['data/octopus_shell.ini']
     },
-    scripts=['scripts/octopus-project', 'scripts/octopus-plugin', 'scripts/octopus-shell', 'scripts/octopus-csvimport']
+    scripts=['scripts/octopus-project', 'scripts/octopus-plugin', 'scripts/octopus-shell', 'scripts/octopus-csvimport', 'scripts/octopus-dgsimport']
 )

--- a/projects/octopus/src/main/java/octopus/api/graphstreamImporter/GraphstreamImporter.java
+++ b/projects/octopus/src/main/java/octopus/api/graphstreamImporter/GraphstreamImporter.java
@@ -1,0 +1,13 @@
+package octopus.api.graphstreamImporter;
+
+import octopus.server.importer.graphstream.ImportGraphstreamRunnable;
+import octopus.server.importer.graphstream.ImportJob;
+
+public class GraphstreamImporter {
+
+    public void importGraphstream(ImportJob job)
+    {
+        (new ImportGraphstreamRunnable(job)).run();
+    }
+
+}

--- a/projects/octopus/src/main/java/octopus/plugins/graphstreamimporter/GraphstreamImporterPlugin.java
+++ b/projects/octopus/src/main/java/octopus/plugins/graphstreamimporter/GraphstreamImporterPlugin.java
@@ -1,0 +1,22 @@
+package octopus.plugins.graphstreamimporter;
+
+
+import java.nio.file.Paths;
+
+import octopus.api.graphstreamImporter.GraphstreamImporter;
+import octopus.api.plugin.types.OctopusProjectPlugin;
+import octopus.server.importer.graphstream.ImportJob;
+
+public class GraphstreamImporterPlugin extends OctopusProjectPlugin {
+
+    @Override
+    public void execute() throws Exception {
+        String projectName = getProjectName();
+        String pathToProjectDir = getPathToProjectDir();
+        String streamFilename = Paths.get(pathToProjectDir, "stream.dgs").toString();
+
+        ImportJob importJob = new ImportJob(streamFilename, projectName);
+        (new GraphstreamImporter()).importGraphstream(importJob);
+    }
+
+}

--- a/projects/octopus/src/main/java/octopus/server/importer/graphstream/ImportGraphstreamRunnable.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/graphstream/ImportGraphstreamRunnable.java
@@ -1,0 +1,55 @@
+package octopus.server.importer.graphstream;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import octopus.api.database.Database;
+import octopus.api.projects.OctopusProject;
+import octopus.api.projects.ProjectManager;
+import octopus.server.importer.graphstream.titan.GraphstreamImporter;
+
+public class ImportGraphstreamRunnable implements Runnable
+{
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(ImportGraphstreamRunnable.class);
+
+    private final ImportJob importJob;
+
+    public ImportGraphstreamRunnable(ImportJob importJob)
+    {
+        this.importJob = importJob;
+    }
+
+    @Override
+    public void run()
+    {
+
+        GraphstreamImporter gdsBatchImporter = new GraphstreamImporter();
+
+        String streamFilename = importJob.getStreamFilename();
+        String projectName = importJob.getProjectName();
+
+        ProjectManager projectManager = new ProjectManager();
+        OctopusProject project = projectManager.getProjectByName(projectName);
+        if(project == null)
+            throw new RuntimeException("Error: project dos not exist");
+
+        try
+        {
+            Database database = project.getNewDatabaseInstance();
+            gdsBatchImporter.setGraph(database.getGraph());
+            gdsBatchImporter.importGraphstreamFiles(streamFilename);
+            database.closeInstance();
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+        }
+
+        logger.warn("Import finished");
+    }
+
+}

--- a/projects/octopus/src/main/java/octopus/server/importer/graphstream/ImportJob.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/graphstream/ImportJob.java
@@ -1,0 +1,24 @@
+package octopus.server.importer.graphstream;
+
+public class ImportJob
+{
+    private final String streamFilename;
+    private final String projectName;
+
+    public ImportJob(String streamFilename, String projectName)
+    {
+        this.streamFilename = streamFilename;
+        this.projectName = projectName;
+    }
+
+    public String getStreamFilename()
+    {
+        return streamFilename;
+    }
+
+    public String getProjectName()
+    {
+        return projectName;
+    }
+
+}

--- a/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
@@ -142,13 +142,13 @@ public class GraphstreamImporter extends SinkAdapter {
                 try {
 					v.property(VertexProperty.Cardinality.list, attribute, newValue);
 				} catch (com.thinkaurelius.titan.core.SchemaViolationException e) {
-					logger.warn("set property on node {}: list properties are not supported.", nodeId);
+					logger.warn("nodeAttributeChanged on node {}: list properties are not supported.", nodeId);
 				}
 			} else {
 				v.property(attribute, newValue);
 			}
 		} else {
-			logger.warn("set property on node {}: could not find node", nodeId);
+			logger.error("nodeAttributeChanged: could not find node {}", nodeId);
 		}
 	}
 

--- a/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
@@ -56,14 +56,90 @@ public class GraphstreamImporter extends SinkAdapter {
 	}
 
 	@Override
-	public void nodeAdded(String sourceId, long timeId, String nodeId) {
-	    System.out.println("DGS: add node {} from source {}".format(nodeId,sourceId));
-		Vertex vertex = graph.addVertex(KEY, nodeId);
+	public void edgeAttributeAdded(String sourceId, long timeId, String edgeId,
+			String attribute, Object value) {
+		logger.warn("DGS: edgeAttributeAdded");
 	}
 
-	public void nodeAttributeAdded(String sourceId, long timeId, String nodeId) {
-		System.out.println("DGS: add node attribute nodeid={} sourceid={}".format(nodeId,sourceId));
+	@Override
+	public void edgeAttributeChanged(String sourceId, long timeId,
+			String edgeId, String attribute, Object oldValue, Object newValue) {
+		logger.warn("DGS: edgeAttributeChanged");
+	}
+
+	@Override
+	public void edgeAttributeRemoved(String sourceId, long timeId,
+			String edgeId, String attribute) {
+		logger.warn("DGS: edgeAttributeRemoved");
+	}
+
+	@Override
+	public void graphAttributeAdded(String sourceId, long timeId,
+			String attribute, Object value) {
+		logger.warn("DGS: graphAttributeAdded");
+	}
+
+	@Override
+	public void graphAttributeChanged(String sourceId, long timeId,
+			String attribute, Object oldValue, Object newValue) {
+		logger.warn("DGS: graphAttributeChanged");
+	}
+
+	@Override
+	public void graphAttributeRemoved(String sourceId, long timeId,
+			String attribute) {
+		logger.warn("DGS: graphAttributeRemoved");
+	}
+
+	@Override
+	public void nodeAttributeAdded(String sourceId, long timeId, String nodeId,
+			String attribute, Object value) {
+		logger.warn(String.format("DGS: add node attribute nodeid=%s attribute=%s",nodeId,attribute));
+		// logger.warn((String) value);
 		// vertex.property(keys[i - 1], row[i]);
 	}
 
+	@Override
+	public void nodeAttributeChanged(String sourceId, long timeId,
+			String nodeId, String attribute, Object oldValue, Object newValue) {
+		logger.warn("DGS: nodeAttributeChanged");
+	}
+
+	@Override
+	public void nodeAttributeRemoved(String sourceId, long timeId,
+			String nodeId, String attribute) {
+		logger.warn("DGS: nodeAttributeRemoved");
+	}
+
+	@Override
+	public void edgeAdded(String sourceId, long timeId, String edgeId,
+			String fromNodeId, String toNodeId, boolean directed) {
+		logger.warn("DGS: edgeAdded");
+	}
+
+	@Override
+	public void edgeRemoved(String sourceId, long timeId, String edgeId) {
+		logger.warn("DGS: edgeRemoved");
+	}
+
+	@Override
+	public void graphCleared(String sourceId, long timeId) {
+		logger.warn("DGS: graphCleared");
+	}
+
+	@Override
+	public void nodeAdded(String sourceId, long timeId, String nodeId) {
+	    logger.warn(String.format("DGS: add node %s from source %s",nodeId,sourceId));
+		// Vertex vertex = graph.addVertex(KEY, nodeId);
+	}
+
+	@Override
+	public void nodeRemoved(String sourceId, long timeId, String nodeId) {
+		logger.warn(String.format("DGS: nodeRemoved(%s,...,%s)",sourceId,nodeId));
+	}
+
+	@Override
+	public void stepBegins(String sourceId, long timeId, double step) {
+		logger.warn("DGS: stepBegins");
+	}
 }

--- a/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
@@ -5,24 +5,35 @@ import java.io.IOException;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.graphstream.stream.SinkAdapter;
+import org.graphstream.stream.file.FileSource;
+import org.graphstream.stream.file.FileSourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class GraphstreamImporter {
+public class GraphstreamImporter extends SinkAdapter {
 
 	Graph graph;
 
 	private static final Logger logger = LoggerFactory
 			.getLogger(GraphstreamImporter.class);
 
-	public void importGraphstreamFiles(String nodeFilename)
+	public void importGraphstreamFiles(String streamFilename)
 			throws IOException
 	{
 		// create graphstream sink (implement one that adds elements to octopus)
 		// create a file source
+		FileSource fs = FileSourceFactory.sourceFor(streamFilename);
 		// connect the two
-		// fs.readAll(path)
+		fs.addSink(this);
+		try {
+			fs.readAll(streamFilename);
+		} catch (IOException e) {
+			// ...
+		} finally {
+			fs.removeSink(this);
+		}
 
 		closeDatabase();
 	}

--- a/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
@@ -123,7 +123,7 @@ public class GraphstreamImporter extends SinkAdapter {
 		return sb.toString();
 	}
 
-	protected Vertex findNodeWithKey(String key) {
+	protected Vertex findVertexWithKey(String key) {
 		GraphTraversalSource g = graph.traversal();
 		GraphTraversal traversal = g.V().has(KEY,key);
         if (traversal.hasNext()) {
@@ -135,7 +135,7 @@ public class GraphstreamImporter extends SinkAdapter {
 	@Override
 	public void nodeAttributeChanged(String sourceId, long timeId,
 			String nodeId, String attribute, Object oldValue, Object newValue) {
-        Vertex v = findNodeWithKey(nodeId);
+        Vertex v = findVertexWithKey(nodeId);
 		if (v != null) {
             if (newValue.getClass().isArray()) {
             	// Cardinality.list is not supported by default in TitanDB, but we can always try

--- a/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
@@ -14,6 +14,8 @@ import org.slf4j.LoggerFactory;
 
 public class GraphstreamImporter extends SinkAdapter {
 
+	static final String KEY = "_key";
+
 	Graph graph;
 
 	private static final Logger logger = LoggerFactory
@@ -38,7 +40,6 @@ public class GraphstreamImporter extends SinkAdapter {
 		closeDatabase();
 	}
 
-
 	public void setGraph(Graph graph)
 	{
 		this.graph = graph;
@@ -52,6 +53,17 @@ public class GraphstreamImporter extends SinkAdapter {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
+	}
+
+	@Override
+	public void nodeAdded(String sourceId, long timeId, String nodeId) {
+	    System.out.println("DGS: add node {} from source {}".format(nodeId,sourceId));
+		Vertex vertex = graph.addVertex(KEY, nodeId);
+	}
+
+	public void nodeAttributeAdded(String sourceId, long timeId, String nodeId) {
+		System.out.println("DGS: add node attribute nodeid={} sourceid={}".format(nodeId,sourceId));
+		// vertex.property(keys[i - 1], row[i]);
 	}
 
 }

--- a/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
@@ -1,10 +1,13 @@
 package octopus.server.importer.graphstream.titan;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 
-import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.graphstream.stream.SinkAdapter;
 import org.graphstream.stream.file.FileSource;
 import org.graphstream.stream.file.FileSourceFactory;
@@ -14,9 +17,11 @@ import org.slf4j.LoggerFactory;
 
 public class GraphstreamImporter extends SinkAdapter {
 
+	static final int NELEMS_PER_TRANSACTION = 100000;
 	static final String KEY = "_key";
 
 	Graph graph;
+	int transaction_element_count = 0;
 
 	private static final Logger logger = LoggerFactory
 			.getLogger(GraphstreamImporter.class);
@@ -24,10 +29,7 @@ public class GraphstreamImporter extends SinkAdapter {
 	public void importGraphstreamFiles(String streamFilename)
 			throws IOException
 	{
-		// create graphstream sink (implement one that adds elements to octopus)
-		// create a file source
 		FileSource fs = FileSourceFactory.sourceFor(streamFilename);
-		// connect the two
 		fs.addSink(this);
 		try {
 			fs.readAll(streamFilename);
@@ -35,6 +37,7 @@ public class GraphstreamImporter extends SinkAdapter {
 			// ...
 		} finally {
 			fs.removeSink(this);
+			flushTransactionsForced();
 		}
 
 		closeDatabase();
@@ -55,91 +58,134 @@ public class GraphstreamImporter extends SinkAdapter {
 		}
 	}
 
+	public void flushTransactionsForced() {
+	    flushTransactions(true);
+    }
+
+	public void flushTransactions(boolean force) {
+		transaction_element_count++;
+		if ( (transaction_element_count > NELEMS_PER_TRANSACTION) || force) {
+			graph.tx().commit();
+            transaction_element_count = 0;
+		}
+	}
+
 	@Override
 	public void edgeAttributeAdded(String sourceId, long timeId, String edgeId,
 			String attribute, Object value) {
-		logger.warn("DGS: edgeAttributeAdded");
+		logger.warn("edgeAttributeAdded not implemented");
 	}
 
 	@Override
 	public void edgeAttributeChanged(String sourceId, long timeId,
 			String edgeId, String attribute, Object oldValue, Object newValue) {
-		logger.warn("DGS: edgeAttributeChanged");
+		logger.warn("edgeAttributeChanged not implemented");
 	}
 
 	@Override
 	public void edgeAttributeRemoved(String sourceId, long timeId,
 			String edgeId, String attribute) {
-		logger.warn("DGS: edgeAttributeRemoved");
+		logger.warn("edgeAttributeRemoved not implemented");
 	}
 
 	@Override
 	public void graphAttributeAdded(String sourceId, long timeId,
 			String attribute, Object value) {
-		logger.warn("DGS: graphAttributeAdded");
+		logger.warn("graphAttributeAdded not implemented");
 	}
 
 	@Override
 	public void graphAttributeChanged(String sourceId, long timeId,
 			String attribute, Object oldValue, Object newValue) {
-		logger.warn("DGS: graphAttributeChanged");
+		logger.warn("graphAttributeChanged not implemented");
 	}
 
 	@Override
 	public void graphAttributeRemoved(String sourceId, long timeId,
 			String attribute) {
-		logger.warn("DGS: graphAttributeRemoved");
+		logger.warn("graphAttributeRemoved not implemented");
 	}
 
 	@Override
 	public void nodeAttributeAdded(String sourceId, long timeId, String nodeId,
 			String attribute, Object value) {
-		logger.warn(String.format("DGS: add node attribute nodeid=%s attribute=%s",nodeId,attribute));
-		// logger.warn((String) value);
-		// vertex.property(keys[i - 1], row[i]);
+        nodeAttributeChanged(sourceId,timeId,nodeId,attribute,null,value);
+	}
+
+	protected static String arraystring(Object value) {
+		StringBuilder sb = new StringBuilder();
+		for(int i=0; i< Array.getLength(value); i++) {
+			if (i!=0) {
+				sb.append(",");
+			}
+			sb.append(String.format(String.valueOf(Array.get(value,i))));
+		}
+		return sb.toString();
+	}
+
+	protected Vertex findNodeWithKey(String key) {
+		GraphTraversalSource g = graph.traversal();
+		GraphTraversal traversal = g.V().has(KEY,key);
+        if (traversal.hasNext()) {
+			return (Vertex) traversal.next();
+		}
+		return null;
 	}
 
 	@Override
 	public void nodeAttributeChanged(String sourceId, long timeId,
 			String nodeId, String attribute, Object oldValue, Object newValue) {
-		logger.warn("DGS: nodeAttributeChanged");
+        Vertex v = findNodeWithKey(nodeId);
+		if (v != null) {
+            if (newValue.getClass().isArray()) {
+            	// Cardinality.list is not supported by default in TitanDB, but we can always try
+                try {
+					v.property(VertexProperty.Cardinality.list, attribute, newValue);
+				} catch (com.thinkaurelius.titan.core.SchemaViolationException e) {
+					logger.warn("set property on node {}: list properties are not supported.", nodeId);
+				}
+			} else {
+				v.property(attribute, newValue);
+			}
+		} else {
+			logger.warn("set property on node {}: could not find node", nodeId);
+		}
 	}
 
 	@Override
 	public void nodeAttributeRemoved(String sourceId, long timeId,
 			String nodeId, String attribute) {
-		logger.warn("DGS: nodeAttributeRemoved");
+		logger.warn("nodeAttributeRemoved not implemented");
 	}
 
 	@Override
 	public void edgeAdded(String sourceId, long timeId, String edgeId,
 			String fromNodeId, String toNodeId, boolean directed) {
-		logger.warn("DGS: edgeAdded");
+		logger.warn("edgeAdded not implemented");
 	}
 
 	@Override
 	public void edgeRemoved(String sourceId, long timeId, String edgeId) {
-		logger.warn("DGS: edgeRemoved");
+		logger.warn("edgeRemoved not implemented");
 	}
 
 	@Override
 	public void graphCleared(String sourceId, long timeId) {
-		logger.warn("DGS: graphCleared");
+		logger.warn("graphCleared not implemented");
 	}
 
 	@Override
 	public void nodeAdded(String sourceId, long timeId, String nodeId) {
-	    logger.warn(String.format("DGS: add node %s from source %s",nodeId,sourceId));
-		// Vertex vertex = graph.addVertex(KEY, nodeId);
+		Vertex vertex = graph.addVertex(KEY, nodeId);
 	}
 
 	@Override
 	public void nodeRemoved(String sourceId, long timeId, String nodeId) {
-		logger.warn(String.format("DGS: nodeRemoved(%s,...,%s)",sourceId,nodeId));
+		logger.warn("nodeRemoved not implemented");
 	}
 
 	@Override
 	public void stepBegins(String sourceId, long timeId, double step) {
-		logger.warn("DGS: stepBegins");
+		logger.warn("stepBegins not implemented");
 	}
 }

--- a/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
+++ b/projects/octopus/src/main/java/octopus/server/importer/graphstream/titan/GraphstreamImporter.java
@@ -1,0 +1,46 @@
+package octopus.server.importer.graphstream.titan;
+
+import java.io.IOException;
+
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class GraphstreamImporter {
+
+	Graph graph;
+
+	private static final Logger logger = LoggerFactory
+			.getLogger(GraphstreamImporter.class);
+
+	public void importGraphstreamFiles(String nodeFilename)
+			throws IOException
+	{
+		// create graphstream sink (implement one that adds elements to octopus)
+		// create a file source
+		// connect the two
+		// fs.readAll(path)
+
+		closeDatabase();
+	}
+
+
+	public void setGraph(Graph graph)
+	{
+		this.graph = graph;
+	}
+
+	public void closeDatabase()
+	{
+		try {
+			graph.close();
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/projects/octopus/src/main/java/octopus/server/restServer/OctopusRestServer.java
+++ b/projects/octopus/src/main/java/octopus/server/restServer/OctopusRestServer.java
@@ -5,14 +5,7 @@ import static spark.Spark.get;
 import static spark.Spark.port;
 import static spark.Spark.post;
 
-import octopus.server.restServer.handlers.CreateProjectHandler;
-import octopus.server.restServer.handlers.CreateShellHandler;
-import octopus.server.restServer.handlers.DeleteProjectHandler;
-import octopus.server.restServer.handlers.ExecutePluginHandler;
-import octopus.server.restServer.handlers.ImportCSVHandler;
-import octopus.server.restServer.handlers.ListProjectsHandler;
-import octopus.server.restServer.handlers.ListShellsHandler;
-import octopus.server.restServer.handlers.ResetDatabaseHandler;
+import octopus.server.restServer.handlers.*;
 
 
 public class OctopusRestServer {
@@ -60,6 +53,14 @@ public class OctopusRestServer {
 
 		get("database/importcsv/:projectName/:nodeFilename/:edgeFilename", (req, res) -> {
 			return new ImportCSVHandler().handle(req, res);
+		});
+
+		get("database/importdgs/:projectName", (req, res) -> {
+			return new ImportGraphstreamHandler().handle(req, res);
+		});
+
+		get("database/importdgs/:projectName/:streamFilename", (req, res) -> {
+			return new ImportGraphstreamHandler().handle(req, res);
 		});
 
 		get("database/reset/:projectName", (req, res) -> {

--- a/projects/octopus/src/main/java/octopus/server/restServer/handlers/ImportGraphstreamHandler.java
+++ b/projects/octopus/src/main/java/octopus/server/restServer/handlers/ImportGraphstreamHandler.java
@@ -1,0 +1,30 @@
+package octopus.server.restServer.handlers;
+
+import octopus.api.graphstreamImporter.GraphstreamImporter;
+import octopus.server.importer.graphstream.ImportJob;
+import octopus.server.restServer.OctopusRestHandler;
+import spark.Request;
+import spark.Response;
+
+public class ImportGraphstreamHandler implements OctopusRestHandler {
+
+    @Override
+    public Object handle(Request req, Response resp)
+    {
+        ImportJob job = getImportJobFromRequest(req);
+        new GraphstreamImporter().importGraphstream(job);
+        return "";
+    }
+
+    private ImportJob getImportJobFromRequest(Request req)
+    {
+        String streamFilename = req.params(":streamFilename");
+        String projectName = req.params(":projectName");
+
+        if(streamFilename == null)
+            streamFilename = "stream.dgs";
+
+        return new ImportJob(streamFilename, projectName);
+    }
+
+}


### PR DESCRIPTION
An importer for the Graphstream DGS format (with limitations).
DGS is a little more flexible than the Octopus CSV format, but still event based.

http://graphstream-project.org/doc/Advanced-Concepts/The-DGS-File-Format/

Edge identifiers need to have the following form:
edge_label`:`source_node_id`:`dest_node_id

Example:

```
an v123 code="x=\"a\";"
an v456 code="x++;"
ae "FLOWS_TO:v123:v456" v123 > v456 var:"a"

multi-valued properties are not supported in Octopus (perhaps a TitanDB setting), therefore property lists are not processed by default.